### PR TITLE
feat(nodejs): add bindings for tx_templates create and find_by_code methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ target/
 -
 .e2e-logs
 .rust-example-logs
+.nodejs-example-logs
 .cala
 .env
 .bacon-locations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [cala release v0.11.5](https://github.com/GaloyMoney/cala/releases/tag/0.11.5)
-
-
-### Miscellaneous Tasks
-
-- Update cala-nodejs napi to 3.x (#554)
-
 # [cala release v0.11.4](https://github.com/GaloyMoney/cala/releases/tag/0.11.4)
 
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ check-code: sdl
 build:
 	SQLX_OFFLINE=true cargo build --locked
 
-e2e: clean-deps start-deps build
+build-nodejs-bindings:
+	cd cala-nodejs && yarn && SQLX_OFFLINE=true yarn build
+	cd examples/nodejs && rm -rf ./node_modules && yarn install
+
+e2e: clean-deps start-deps build build-nodejs-bindings
 	bats -t bats
 
 sdl:

--- a/bats/gql/tx-template-find-by-code.gql
+++ b/bats/gql/tx-template-find-by-code.gql
@@ -1,0 +1,8 @@
+query txTemplateByCode($code: String!) {
+  txTemplateByCode(code: $code) {
+    id
+    txTemplateId
+    version
+    code
+  }
+}

--- a/bats/helpers.bash
+++ b/bats/helpers.bash
@@ -2,11 +2,13 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-${REPO_ROOT##*/}}"
 
 GQL_ENDPOINT="http://localhost:2252/graphql"
+PG_CON_EXAMPLE="${PG_CON_EXAMPLE:-postgres://user:password@127.0.0.1:5433/pg}"
 
 CALA_HOME="${CALA_HOME:-.cala}"
 SERVER_PID_FILE="${CALA_HOME}/server-pid"
-EXAMPLE_PID_FILE="${CALA_HOME}/rust-example-pid"
 DOCKER_ENGINE="${DOCKER_ENGINE:-docker}"
+RUST_EXAMPLE_PID_FILE="${CALA_HOME}/rust-example-pid"
+NODEJS_EXAMPLE_PID_FILE="${CALA_HOME}/nodejs-example-pid"
 
 reset_pg() {
   $DOCKER_ENGINE exec "${COMPOSE_PROJECT_NAME}-server-pg-1" psql $PG_CON -c "DROP SCHEMA public CASCADE"
@@ -59,8 +61,14 @@ stop_server() {
 }
 
 stop_rust_example() {
-  if [[ -f "$EXAMPLE_PID_FILE" ]]; then
-    kill -9 $(cat "$EXAMPLE_PID_FILE") || true
+  if [[ -f "$RUST_EXAMPLE_PID_FILE" ]]; then
+    kill -9 $(cat "$RUST_EXAMPLE_PID_FILE") || true
+  fi
+}
+
+stop_nodejs_example() {
+  if [[ -f "$NODEJS_EXAMPLE_PID_FILE" ]]; then
+    kill -9 $(cat "$NODEJS_EXAMPLE_PID_FILE") || true
   fi
 }
 
@@ -135,4 +143,11 @@ random_uuid() {
   else
     uuidgen | tr '[:upper:]' '[:lower:]'
   fi
+}
+
+wait_for_new_import_job() {
+  job_count=$1
+
+  new_job_count=$(cat .e2e-logs | grep 'Executing CalaOutboxImportJob importing' | wc -l)
+  [[ "$new_job_count" -gt "$job_count" ]] || return 1
 }

--- a/bats/nodejs-examples.bats
+++ b/bats/nodejs-examples.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+load "helpers"
+
+setup_file() {
+  reset_pg_and_restart_server
+}
+
+teardown_file() {
+  stop_server
+  stop_nodejs_example
+}
+
+reset_pg_and_restart_server() {
+  stop_server
+  reset_pg
+  PG_CON=$PG_CON_EXAMPLE start_server
+}
+
+@test "nodejs: entities sync to server" {
+  reset_pg_and_restart_server
+
+  exec_graphql 'list-accounts'
+  accounts_before=$(graphql_output '.data.accounts.nodes | length')
+
+  job_id=$(random_uuid)
+  variables=$(
+    jq -n \
+      --arg jobId "$job_id" \
+    '{
+      input: {
+        jobId: $jobId,
+        endpoint: "http://localhost:2258"
+      }
+    }'
+  )
+  exec_graphql 'cala-outbox-import-job-create' "$variables"
+  echo "GraphQL Response: $(graphql_output)"
+  id=$(graphql_output '.data.calaOutboxImportJobCreate.job.jobId')
+  error_msg=$(graphql_output '.errors[0].message')
+  [[ "$id" == "$job_id" || "$error_msg" =~ duplicate.*jobs_name_key ]] || exit 1;
+
+  background bash -c "cd ${REPO_ROOT}/examples/nodejs && npm run start > ${REPO_ROOT}/.nodejs-example-logs 2>&1" &
+  NODEJS_EXAMPLE_PID=$!
+  echo $NODEJS_EXAMPLE_PID > "${NODEJS_EXAMPLE_PID_FILE}"
+
+  job_count=$(cat .e2e-logs | grep 'Executing CalaOutboxImportJob importing' | wc -l)
+  retry 30 1 wait_for_new_import_job $job_count || true
+  sleep 1
+
+  for i in {1..90}; do
+    exec_graphql 'list-accounts'
+    accounts_after=$(graphql_output '.data.accounts.nodes | length')
+    if [[ "$accounts_after" -gt "$accounts_before" ]] then
+      break;
+    fi
+    sleep 1
+  done
+
+  [[ "$accounts_after" -gt "$accounts_before" ]] || exit 1
+
+  variables=$(
+    jq -n \
+      --arg code "RECORD_DEPOSIT" \
+    '{"code": $code}'
+  )
+  exec_graphql 'tx-template-find-by-code' "$variables"
+  tx_template_code=$(graphql_output '.data.txTemplateFindByCode.txTemplate.code')
+  [[ "$tx_template_code" != "RECORD_DEPOSIT" ]] || exit 1
+}

--- a/bats/rust-examples.bats
+++ b/bats/rust-examples.bats
@@ -11,14 +11,6 @@ teardown_file() {
   stop_rust_example
 }
 
-wait_for_new_import_job() {
-  job_count=$1
-
-  new_job_count=$(cat .e2e-logs | grep 'Executing CalaOutboxImportJob importing' | wc -l)
-  [[ "$new_job_count" -gt "$job_count" ]] || return 1
-}
-
-
 @test "rust: entities sync to server" {
   exec_graphql 'list-accounts'
   accounts_before=$(graphql_output '.data.accounts.nodes | length')

--- a/cala-nodejs/Cargo.toml
+++ b/cala-nodejs/Cargo.toml
@@ -12,7 +12,7 @@ cala-types = { workspace = true }
 cala-ledger = { workspace = true }
 
 base64 = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v7"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 napi = { version = "3.3.0", default-features = false, features = ["tokio_rt", "serde-json"] }

--- a/cala-nodejs/index.d.ts
+++ b/cala-nodejs/index.d.ts
@@ -17,13 +17,25 @@ export declare class CalaJournal {
 
 export declare class CalaJournals {
   create(newJournal: NewJournal): Promise<CalaJournal>
+  find(journalId: string): Promise<CalaJournal>
 }
 
 export declare class CalaLedger {
   static connect(config: CalaLedgerConfig): Promise<CalaLedger>
   accounts(): CalaAccounts
   journals(): CalaJournals
+  txTemplates(): CalaTxTemplates
   awaitOutboxServer(): Promise<void>
+}
+
+export declare class CalaTxTemplate {
+  id(): string
+  values(): TxTemplateValues
+}
+
+export declare class CalaTxTemplates {
+  findByCode(code: string): Promise<CalaTxTemplate>
+  create(newTxTemplate: NewTxTemplateValues): Promise<CalaTxTemplate>
 }
 
 export interface AccountValues {
@@ -48,6 +60,7 @@ export interface CursorToken {
 export interface JournalValues {
   id: string
   name: string
+  code?: string
   description?: string
 }
 
@@ -63,8 +76,47 @@ export interface NewAccount {
 export interface NewJournal {
   id?: string
   name: string
+  code: string
   externalId?: string
   description?: string
+}
+
+export interface NewParamDefinitionValues {
+  name: string
+  type: ParamDataTypeValues
+  default?: string
+  description?: string
+}
+
+export interface NewTxTemplateEntryValues {
+  entryType: string
+  accountId: string
+  layer: string
+  direction: string
+  units: string
+  currency: string
+  description?: string
+  metadata?: string
+}
+
+export interface NewTxTemplateTransactionValues {
+  effective: string
+  journalId: string
+  correlationId?: string
+  externalId?: string
+  description?: string
+  metadata?: string
+}
+
+export interface NewTxTemplateValues {
+  id?: string
+  code: string
+  externalId?: string
+  description?: string
+  params?: Array<NewParamDefinitionValues>
+  entries: Array<NewTxTemplateEntryValues>
+  metadata?: any
+  transaction?: NewTxTemplateTransactionValues
 }
 
 export interface OutboxServerConfig {
@@ -81,4 +133,23 @@ export interface PaginatedAccounts {
 export interface PaginatedQueryArgs {
   after?: CursorToken
   first: number
+}
+
+export declare const enum ParamDataTypeValues {
+  String = 0,
+  Integer = 1,
+  Decimal = 2,
+  Boolean = 3,
+  Uuid = 4,
+  Date = 5,
+  Timestamp = 6,
+  Json = 7
+}
+
+export interface TxTemplateValues {
+  id: string
+  code: string
+  version: number
+  metadata?: any
+  description?: string
 }

--- a/cala-nodejs/index.js
+++ b/cala-nodejs/index.js
@@ -562,3 +562,6 @@ module.exports.CalaAccounts = nativeBinding.CalaAccounts
 module.exports.CalaJournal = nativeBinding.CalaJournal
 module.exports.CalaJournals = nativeBinding.CalaJournals
 module.exports.CalaLedger = nativeBinding.CalaLedger
+module.exports.CalaTxTemplate = nativeBinding.CalaTxTemplate
+module.exports.CalaTxTemplates = nativeBinding.CalaTxTemplates
+module.exports.ParamDataTypeValues = nativeBinding.ParamDataTypeValues

--- a/cala-nodejs/src/journal/mod.rs
+++ b/cala-nodejs/src/journal/mod.rs
@@ -1,11 +1,13 @@
 mod values;
 
+use cala_ledger::{journal::error::JournalError, JournalId};
 use values::*;
 
 #[napi(object)]
 pub struct NewJournal {
   pub id: Option<String>,
   pub name: String,
+  pub code: String,
   pub external_id: Option<String>,
   pub description: Option<String>,
 }
@@ -60,6 +62,20 @@ impl CalaJournals {
       .create(new.build().map_err(crate::generic_napi_error)?)
       .await
       .map_err(crate::generic_napi_error)?;
+    Ok(CalaJournal { inner: journal })
+  }
+
+  #[napi]
+  pub async fn find(&self, journal_id: String) -> napi::Result<CalaJournal> {
+    let journal_id = uuid::Uuid::parse_str(&journal_id).map_err(crate::generic_napi_error)?;
+
+    let journal_id = JournalId::from(journal_id);
+
+    let journal = self
+      .inner
+      .find(journal_id)
+      .await
+      .map_err(|e: JournalError| crate::generic_napi_error(e))?;
     Ok(CalaJournal { inner: journal })
   }
 }

--- a/cala-nodejs/src/journal/values.rs
+++ b/cala-nodejs/src/journal/values.rs
@@ -2,6 +2,7 @@
 pub struct JournalValues {
   pub id: String,
   pub name: String,
+  pub code: Option<String>,
   pub description: Option<String>,
 }
 
@@ -10,7 +11,8 @@ impl From<&cala_ledger::journal::Journal> for JournalValues {
     let values = journal.values().clone();
     Self {
       id: values.id.to_string(),
-      name: values.name,
+      name: values.name.clone(),
+      code: values.code.clone().or(None),
       description: values.description,
     }
   }
@@ -21,7 +23,8 @@ impl From<cala_ledger::journal::Journal> for JournalValues {
     let values = journal.into_values();
     Self {
       id: values.id.to_string(),
-      name: values.name,
+      name: values.name.clone(),
+      code: values.code.clone().or(None),
       description: values.description,
     }
   }

--- a/cala-nodejs/src/ledger/mod.rs
+++ b/cala-nodejs/src/ledger/mod.rs
@@ -2,6 +2,8 @@ mod config;
 
 pub use config::*;
 
+use crate::tx_template::CalaTxTemplates;
+
 use super::{account::*, journal::*};
 
 #[napi]
@@ -43,6 +45,11 @@ impl CalaLedger {
   #[napi]
   pub fn journals(&self) -> napi::Result<CalaJournals> {
     Ok(CalaJournals::new(self.inner.journals()))
+  }
+
+  #[napi]
+  pub fn tx_templates(&self) -> napi::Result<CalaTxTemplates> {
+    Ok(CalaTxTemplates::new(self.inner.tx_templates()))
   }
 
   #[napi]

--- a/cala-nodejs/src/lib.rs
+++ b/cala-nodejs/src/lib.rs
@@ -8,5 +8,6 @@ mod generic_error;
 mod journal;
 mod ledger;
 mod query;
+mod tx_template;
 
 pub(crate) use generic_error::generic_napi_error;

--- a/cala-nodejs/src/tx_template/mod.rs
+++ b/cala-nodejs/src/tx_template/mod.rs
@@ -1,0 +1,161 @@
+mod values;
+
+use cala_ledger::velocity::NewParamDefinition;
+use cala_types::param::ParamDataType;
+use values::*;
+
+#[napi]
+pub struct CalaTxTemplates {
+  inner: cala_ledger::tx_template::TxTemplates,
+}
+
+#[napi]
+pub struct CalaTxTemplate {
+  inner: cala_ledger::tx_template::TxTemplate,
+}
+
+#[napi]
+impl CalaTxTemplate {
+  #[napi]
+  pub fn id(&self) -> String {
+    self.inner.id().to_string()
+  }
+
+  #[napi]
+  pub fn values(&self) -> TxTemplateValues {
+    TxTemplateValues::from(&self.inner)
+  }
+}
+
+#[napi]
+impl CalaTxTemplates {
+  pub fn new(inner: &cala_ledger::tx_template::TxTemplates) -> Self {
+    Self {
+      inner: inner.clone(),
+    }
+  }
+
+  #[napi]
+  pub async fn find_by_code(&self, code: String) -> napi::Result<CalaTxTemplate> {
+    let template = self
+      .inner
+      .find_by_code(code)
+      .await
+      .map_err(crate::generic_napi_error)?;
+
+    Ok(CalaTxTemplate { inner: template })
+  }
+
+  #[napi]
+  pub async fn create(&self, new_tx_template: NewTxTemplateValues) -> napi::Result<CalaTxTemplate> {
+    let id = if let Some(id) = new_tx_template.id {
+      id.parse::<cala_ledger::TxTemplateId>()
+        .map_err(crate::generic_napi_error)?
+    } else {
+      cala_ledger::TxTemplateId::new()
+    };
+
+    let mut tx_template_params = Vec::new();
+
+    let mut new = cala_ledger::tx_template::NewTxTemplate::builder();
+
+    if let Some(params) = new_tx_template.params {
+      for param in params {
+        let param_type = match param.r#type {
+          ParamDataTypeValues::String => ParamDataType::String,
+          ParamDataTypeValues::Integer => ParamDataType::Integer,
+          ParamDataTypeValues::Decimal => ParamDataType::Decimal,
+          ParamDataTypeValues::Boolean => ParamDataType::Boolean,
+          ParamDataTypeValues::Uuid => ParamDataType::Uuid,
+          ParamDataTypeValues::Date => ParamDataType::Date,
+          ParamDataTypeValues::Timestamp => ParamDataType::Timestamp,
+          ParamDataTypeValues::Json => ParamDataType::Json,
+        };
+        let mut param_builder = NewParamDefinition::builder();
+        param_builder.name(param.name).r#type(param_type);
+
+        tx_template_params.push(param_builder.build().map_err(crate::generic_napi_error)?);
+      }
+
+      new.params(tx_template_params.clone());
+    }
+
+    new.id(id).code(new_tx_template.code);
+    if let Some(description) = new_tx_template.description {
+      new.description(description);
+    }
+
+    if let Some(transaction) = new_tx_template.transaction {
+      let mut new_transaction =
+        cala_ledger::tx_template::NewTxTemplateTransactionBuilder::default();
+
+      new_transaction.effective(transaction.effective);
+      new_transaction.journal_id(transaction.journal_id);
+
+      if let Some(correlation_id) = transaction.correlation_id {
+        new_transaction.correlation_id(correlation_id);
+      }
+
+      if let Some(external_id) = transaction.external_id {
+        new_transaction.external_id(external_id);
+      }
+
+      if let Some(description) = transaction.description {
+        new_transaction.description(description);
+      }
+
+      if let Some(metadata) = transaction.metadata {
+        new_transaction.metadata(metadata);
+      }
+
+      new.transaction(new_transaction.build().map_err(crate::generic_napi_error)?);
+    } else {
+      return Err(napi::Error::from_reason(
+        "Transaction details are required".to_string(),
+      ));
+    }
+
+    if let Some(metadata) = new_tx_template.metadata {
+      let _ = new.metadata(metadata);
+    }
+
+    let mut tx_template_entries = Vec::new();
+
+    if new_tx_template.entries.is_empty() {
+      return Err(napi::Error::from_reason(
+        "At least one entry is required".to_string(),
+      ));
+    }
+
+    for entry in new_tx_template.entries {
+      let mut entry_builder = cala_ledger::tx_template::NewTxTemplateEntry::builder();
+
+      entry_builder
+        .entry_type(entry.entry_type)
+        .account_id(entry.account_id)
+        .layer(entry.layer)
+        .direction(entry.direction)
+        .units(entry.units)
+        .currency(entry.currency);
+
+      if let Some(description) = entry.description {
+        entry_builder.description(description);
+      }
+
+      if let Some(metadata) = entry.metadata {
+        entry_builder.metadata(metadata);
+      }
+
+      tx_template_entries.push(entry_builder.build().map_err(crate::generic_napi_error)?);
+    }
+
+    new.entries(tx_template_entries.clone());
+
+    let tx_template = self
+      .inner
+      .create(new.build().map_err(crate::generic_napi_error)?)
+      .await
+      .map_err(crate::generic_napi_error)?;
+    Ok(CalaTxTemplate { inner: tx_template })
+  }
+}

--- a/cala-nodejs/src/tx_template/values.rs
+++ b/cala-nodejs/src/tx_template/values.rs
@@ -1,0 +1,88 @@
+#[napi(object)]
+pub struct NewParamDefinitionValues {
+  pub name: String,
+  pub r#type: ParamDataTypeValues,
+  pub default: Option<String>,
+  pub description: Option<String>,
+}
+
+#[napi(object)]
+pub struct NewTxTemplateEntryValues {
+  pub entry_type: String,
+  pub account_id: String,
+  pub layer: String,
+  pub direction: String,
+  pub units: String,
+  pub currency: String,
+  pub description: Option<String>,
+  pub metadata: Option<String>,
+}
+
+#[napi(object)]
+pub struct NewTxTemplateValues {
+  pub id: Option<String>,
+  pub code: String,
+  pub external_id: Option<String>,
+  pub description: Option<String>,
+  pub params: Option<Vec<NewParamDefinitionValues>>,
+  pub entries: Vec<NewTxTemplateEntryValues>,
+  pub metadata: Option<serde_json::Value>,
+  pub transaction: Option<NewTxTemplateTransactionValues>,
+}
+
+#[napi(object)]
+pub struct NewTxTemplateTransactionValues {
+  pub effective: String,
+  pub journal_id: String,
+  pub correlation_id: Option<String>,
+  pub external_id: Option<String>,
+  pub description: Option<String>,
+  pub metadata: Option<String>,
+}
+
+#[napi(object)]
+pub struct TxTemplateValues {
+  pub id: String,
+  pub code: String,
+  pub version: u32,
+  pub metadata: Option<serde_json::Value>,
+  pub description: Option<String>,
+}
+
+#[napi]
+pub enum ParamDataTypeValues {
+  String,
+  Integer,
+  Decimal,
+  Boolean,
+  Uuid,
+  Date,
+  Timestamp,
+  Json,
+}
+
+impl From<&cala_ledger::tx_template::TxTemplate> for TxTemplateValues {
+  fn from(template: &cala_ledger::tx_template::TxTemplate) -> Self {
+    let values = template.values().clone();
+    Self {
+      id: values.id.to_string(),
+      code: values.code.to_string(),
+      description: values.description,
+      metadata: values.metadata,
+      version: values.version,
+    }
+  }
+}
+
+impl From<cala_ledger::tx_template::TxTemplate> for TxTemplateValues {
+  fn from(template: cala_ledger::tx_template::TxTemplate) -> Self {
+    let values = template.into_values();
+    Self {
+      id: values.id.to_string(),
+      code: values.code.to_string(),
+      description: values.description,
+      metadata: values.metadata,
+      version: values.version,
+    }
+  }
+}

--- a/examples/nodejs/src/index.ts
+++ b/examples/nodejs/src/index.ts
@@ -1,10 +1,19 @@
-import { CalaLedger } from "@galoymoney/cala-ledger";
+import {
+  CalaLedger,
+  NewTxTemplateTransactionValues,
+  NewTxTemplateEntryValues,
+  NewParamDefinitionValues,
+  ParamDataTypeValues,
+} from "@galoymoney/cala-ledger";
 
 const main = async () => {
   const pgHost = process.env.PG_HOST || "localhost";
-  const pgCon = `postgres://user:password@${pgHost}:5432/pg`;
+  const pgCon = `postgres://user:password@${pgHost}:5433/pg`;
 
-  const cala = await CalaLedger.connect({ pgCon, outbox: { enabled: true } });
+  const cala = await CalaLedger.connect({
+    pgCon,
+    outbox: { enabled: true, listenPort: 2258 },
+  });
   console.log("CalaLedger connected");
 
   const account = await cala.accounts().create({
@@ -36,9 +45,86 @@ const main = async () => {
   const journal = await cala.journals().create({
     name: "MY JOURNAL",
     description: "MY DESCRIPTION",
+    code: "MY_JOURNAL",
   });
 
   console.log("Journal Created", journal.id());
+
+  const recordDepositDrEntry: NewTxTemplateEntryValues = {
+    entryType: "'RECORD_DEPOSIT_DR'",
+    currency: "params.currency",
+    accountId: "params.deposit_omnibus_account_id",
+    direction: "DEBIT",
+    layer: "SETTLED",
+    units: "params.amount",
+  };
+
+  const recordDepositCrEntry: NewTxTemplateEntryValues = {
+    entryType: "'RECORD_DEPOSIT_CR'",
+    currency: "params.currency",
+    accountId: "params.credit_account_id",
+    direction: "CREDIT",
+    layer: "SETTLED",
+    units: "params.amount",
+  };
+
+  const txInput: NewTxTemplateTransactionValues = {
+    journalId: "params.journal_id",
+    effective: "params.effective",
+    metadata: "params.meta",
+    description: "'Record a deposit'",
+  };
+
+  const txParams: NewParamDefinitionValues[] = [
+    {
+      name: "journal_id",
+      type: ParamDataTypeValues.Uuid,
+    },
+    {
+      name: "currency",
+      type: ParamDataTypeValues.String,
+    },
+    {
+      name: "amount",
+      type: ParamDataTypeValues.Decimal,
+    },
+    {
+      name: "deposit_omnibus_account_id",
+      type: ParamDataTypeValues.Uuid,
+    },
+    {
+      name: "credit_account_id",
+      type: ParamDataTypeValues.Uuid,
+    },
+    {
+      name: "effective",
+      type: ParamDataTypeValues.Date,
+    },
+    {
+      name: "meta",
+      type: ParamDataTypeValues.Json,
+    },
+  ];
+
+  const txTemplate = await cala.txTemplates().create({
+    code: "RECORD_DEPOSIT",
+    description: "Record deposit transaction",
+    entries: [recordDepositDrEntry, recordDepositCrEntry],
+    transaction: txInput,
+    params: txParams,
+  });
+
+  console.log(
+    "Tx Template Created",
+    txTemplate.values().id,
+    txTemplate.values().code,
+  );
+
+  const retrievedTxTemplate = await cala
+    .txTemplates()
+    .findByCode("RECORD_DEPOSIT");
+
+  console.log("Retrieved Tx Template", retrievedTxTemplate.values());
 };
 
 main();

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
           napi-rs-cli
           yarn
           nodejs
+          tsx
           typescript
           ytt
           podman


### PR DESCRIPTION
- added `tx_template` bindings
  - `find_by_code` method
  - `create` method (with `transaction` property validation)
- bats tests
  - separated nodejs and rust examples
  - nodejs example checks for accounts and created `tx_template` by its code
- tsx added to `flake.nix` to ensure reproducibility